### PR TITLE
Remove MacBookPro16,3 from Tahoe supported models

### DIFF
--- a/conditions/macos_upgrade_supported.sh
+++ b/conditions/macos_upgrade_supported.sh
@@ -62,7 +62,6 @@ tahoe_upgrade_supported() {
     MacBookAir10,1 | \
     MacBookPro16,1 | \
     MacBookPro16,2 | \
-    MacBookPro16,3 | \
     MacBookPro16,4 | \
     MacBookPro17,1 | \
     MacBookPro18,1 | \


### PR DESCRIPTION
According to [EveryMac](https://everymac.com/mac-answers/macos-26-tahoe-faq/macos-tahoe-macos-26-compatbility-list-system-requirements.html) and a MacAdmins Slack [discussion](https://macadmins.slack.com/archives/C04QVP86E/p1758758818844999?thread_ts=1749495357.963519&cid=C04QVP86E), the MacBookPro16,3 is not supported by macOS Tahoe.